### PR TITLE
compliance: align with AMD-AGI Repository Standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS for AMD-AGI/HF_PEFT_GPT_OSS
+# Per AMD-AGI Repository Standards §2.1.4
+# https://amd.atlassian.net/wiki/spaces/AIMA/pages/1665353888/AMD-AGI+Repository+Standards
+#
+# Order matters: the LAST matching pattern wins for a given file.
+
+# Global catch-all: project team owns everything by default.
+*                       @AMD-AGI/brain-tio
+
+# Governance & CI: stricter review (leads + TPM).
+/.github/               @AMD-AGI/brain-tio-leads @AMD-AGI/brain-tpm
+/CODEOWNERS             @AMD-AGI/brain-tio-leads
+/.github/CODEOWNERS     @AMD-AGI/brain-tio-leads
+/README.md              @AMD-AGI/brain-tio-leads @AMD-AGI/brain-tpm
+/CONTRIBUTING.md        @AMD-AGI/brain-tio-leads @AMD-AGI/brain-tpm
+/SECURITY.md            @AMD-AGI/brain-tio-leads @AMD-AGI/brain-tpm
+/LICENSE                @AMD-AGI/brain-tio-leads @AMD-AGI/brain-tpm

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,228 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or tool, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-in-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstract Syntax Tree (AST) parser cache for Ruff
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  ignore AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml
+
+# ===== Project-specific additions =====
+
+# Local env files
+.env.*
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Experiment tracking / outputs
+wandb/
+outputs/
+runs/
+logs/
+
+# Model checkpoints and weights
+checkpoints/
+models/
+*.safetensors
+*.bin
+*.pt
+*.pth
+*.ckpt
+*.onnx
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to HF_PEFT_GPT_OSS
+
+Thanks for your interest in contributing! This repository hosts a reference
+recipe for PEFT/LoRA fine-tuning of OpenAI GPT-OSS Mixture-of-Experts models on
+AMD MI300/MI355 GPUs with ROCm. We welcome bug reports, fixes, performance
+improvements, and documentation updates.
+
+## Filing issues
+
+Please use GitHub Issues. Before opening a new issue, search existing issues to
+avoid duplicates. A good bug report includes:
+
+- Hardware (e.g. MI300X / MI355X), ROCm version, container image tag.
+- Exact command(s) you ran (e.g. `bash run_peft_lora_openai.sh`).
+- Full error message / traceback.
+- Minimum config (`configs/`) needed to reproduce.
+- What you expected vs. what happened.
+
+For feature requests, describe the use case and, if possible, a sketch of the
+proposed change.
+
+## Pull request workflow
+
+1. Fork the repo (external contributors) or create a feature branch in this
+   repo (internal AMD-AGI contributors). Branch naming: `<type>/<short-desc>`,
+   e.g. `fix/lora-grad-accum`, `perf/mi355-attn-mask`, `docs/readme-clarify`.
+2. Make focused, minimal changes. Keep unrelated refactors out of the PR.
+3. Run any local checks (see "Code style" and "Testing" below).
+4. Open a PR against `main`. Fill in the PR template if present. Link related
+   issues with `Fixes #123` / `Refs #123`.
+5. Every PR requires:
+   - At least **one approval from a non-author** reviewer.
+   - **CODEOWNERS** review for any owned paths (see `.github/CODEOWNERS`).
+   - All required status checks green.
+6. Squash-merge is preferred to keep `main` history readable.
+
+## Code style
+
+- Python: follow PEP 8. We recommend formatting with `black` and linting with
+  `ruff` before pushing:
+  ```bash
+  pip install black ruff
+  black .
+  ruff check .
+  ```
+- Keep imports sorted (`ruff check --select I --fix .` or `isort .`).
+- Prefer clear, surgical changes over clever one-liners.
+- Shell scripts: keep them POSIX-friendly where possible, document any
+  hardware-specific assumptions in comments.
+
+## Testing
+
+This repo does not yet ship an automated test suite. At minimum, when changing
+training/utility code, please verify:
+
+- `bash requirements_MI300.sh` (or `requirements_MI355.sh`, as applicable)
+  still completes inside the documented container.
+- A short `bash run_peft_lora_openai.sh` smoke run starts training and
+  produces at least one loss step without error.
+
+If you add tests, prefer `pytest` and place them under `tests/`.
+
+## Developer Certificate of Origin (DCO)
+
+By contributing, you certify that you wrote (or have the right to submit) the
+contribution under the project's MIT license. Sign off every commit:
+
+```bash
+git commit -s -m "your message"
+```
+
+This adds a `Signed-off-by: Your Name <you@example.com>` trailer.
+
+## Security
+
+Please **do not** open public GitHub issues for security vulnerabilities. See
+[SECURITY.md](SECURITY.md) for the private disclosure process.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+MIT License (see [LICENSE](LICENSE)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,80 @@
+# Security Policy
+
+## Supported versions
+
+This repository tracks active development on the `main` branch. Security fixes
+are applied to `main` only; there are no maintained release branches at this
+time.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| Older commits / forks | :x: |
+
+## Reporting a vulnerability
+
+**Please do not file a public GitHub issue for security problems.**
+
+Preferred channel — GitHub Private Vulnerability Reporting:
+
+- https://github.com/AMD-AGI/HF_PEFT_GPT_OSS/security/advisories/new
+
+Fallback — AMD Product Security Incident Response Team (PSIRT):
+
+- Email: **psirt@amd.com**
+- Reference: https://www.amd.com/en/resources/product-security.html
+
+When reporting, please include:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce (commands, config, hardware/container if relevant).
+- Affected commit SHA or branch.
+- Any proof-of-concept, logs, or sample inputs.
+- Your name / handle for credit (optional).
+
+## Response expectations
+
+- **Acknowledgement:** within **5 business days** of receipt.
+- **Triage & status update:** within **15 business days**.
+- **Fix or documented mitigation:** target within **90 days**, depending on
+  severity and complexity.
+- We follow **coordinated disclosure**: please give us a reasonable window to
+  investigate and ship a fix before public disclosure. We are happy to credit
+  reporters in the resulting advisory.
+
+## Scope
+
+This repository contains training/fine-tuning code, configs, and shell helper
+scripts. Vulnerability classes we are particularly interested in:
+
+- **Code execution / injection** in `train.py`, `utils.py`, or shell scripts
+  (e.g. unsafe handling of user-controlled config values, paths, or shell
+  arguments).
+- **Supply-chain risks** in `requirements_MI300.sh` / `requirements_MI355.sh`
+  (typosquatted, malicious, or compromised dependencies).
+- **Secret / credential leakage** (e.g. accidentally committed Hugging Face
+  tokens, SSH keys, cloud credentials) — please report privately so we can
+  rotate before public disclosure.
+- **AI/ML-specific issues**:
+  - Training-data poisoning vectors introduced by the dataset loading path.
+  - Model-weight tampering or unsafe deserialization (`torch.load` of
+    untrusted checkpoints).
+  - Unsafe defaults that would cause a downstream user to leak prompts, data,
+    or fine-tuned weights.
+
+Out of scope:
+
+- Vulnerabilities in upstream dependencies (PyTorch, Transformers, PEFT,
+  Accelerate, ROCm, Docker images) — please report those to the respective
+  upstream projects. We will, however, update pins/instructions if a known
+  upstream CVE affects users of this repo.
+- Issues that require the attacker to already have root or container-host
+  access.
+- Rate-limiting / DoS of the training script itself.
+
+## Handling secrets
+
+Never commit credentials (Hugging Face tokens, cloud keys, etc.) to this
+repository. The `.gitignore` excludes `.env` / `.env.*` files. If you discover
+a secret in the git history, please report it privately via the channels above
+so we can rotate and purge.


### PR DESCRIPTION
## Summary

Brings this public repo into compliance with the [AMD-AGI Repository Standards](https://amd.atlassian.net/wiki/spaces/AIMA/pages/1665353888/AMD-AGI+Repository+Standards) (public tier — all of §2.1 and §2.2 are required).

## Files added

| File | Standard |
|---|---|
| `.gitignore` | §2.1.3 — GitHub-official Python template + ML/IDE additions (`.env*`, `wandb/`, `outputs/`, `checkpoints/`, `*.safetensors`, `*.bin`, `*.pt`, `*.ckpt`, etc.) |
| `.github/CODEOWNERS` | §2.1.4 — `@AMD-AGI/brain-tio` global catch-all; `@AMD-AGI/brain-tio-leads` + `@AMD-AGI/brain-tpm` guard `.github/`, CODEOWNERS, README, CONTRIBUTING, SECURITY, LICENSE |
| `CONTRIBUTING.md` | §2.2.2 — issues, branch/PR flow, ≥1 non-author + CODEOWNERS approval, `black`/`ruff`, DCO sign-off, link to SECURITY.md |
| `SECURITY.md` | §2.2.3 — supported versions (`main`), GitHub Private Vulnerability Reporting + `psirt@amd.com`, 5-business-day ack / 15-day triage / 90-day fix, AI-specific scope (model poisoning, data injection, supply-chain on requirements scripts, `torch.load` of untrusted checkpoints, secret leakage) |

## Settings-level items (handled out-of-band, NOT in this PR)

- **Topics (§2.1.5)** — set via `gh api -X PUT .../topics`. Now: `brain`, `brain-tio`, `fine-tuning`, `llm`, `python`, `pytorch`, `rocm` (7 topics, covers Org/Team + Domain + Task + Framework + Language).
- **Private Vulnerability Reporting (§2.2.4)** — enabled via `gh api -X PUT .../private-vulnerability-reporting`. Verified `{"enabled":true}`.

## README review (§2.1.1)

Reviewed against §2.1.1 minimum content. The existing README already covers project name + one-line description, prerequisites, and a full step-by-step usage example. It is missing an explicit **license statement** and **team/contact** pointer. These are minor — `LICENSE` is present at the root and CODEOWNERS now provides the contact path — so the README was **left untouched** to avoid a non-surgical rewrite. Suggest a tiny follow-up PR adding a one-line "Licensed under MIT — see [LICENSE](LICENSE). Maintainers: see [CODEOWNERS](.github/CODEOWNERS)." footer if a strict §2.1.1 reading is desired.

## Manual follow-up

- **Branch protection (§3)** — not touched in this PR (requires admin). Please confirm `main` requires PR + ≥1 non-author approval + Code Owners review.

## Test plan

- [ ] Confirm CODEOWNERS team slugs (`brain-tio`, `brain-tio-leads`, `brain-tpm`) exist under @AMD-AGI; adjust if your local convention differs.
- [ ] Confirm `psirt@amd.com` is the right escalation alias for this repo's domain.
- [ ] Verify topics + PVR in the GitHub UI (Settings → General / Settings → Code security).